### PR TITLE
Typo correction in explanatory comments

### DIFF
--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -3,7 +3,7 @@ import cheerio, { CheerioAPI } from "cheerio";
 import axios from "axios";
 
 // We create separate interfaces for each page type to make sure that the
-// corret type of page is passed to each method that extracts data.
+// correct type of page is passed to each method that extracts data.
 // Other than this, all pages are instances of CheerioAPI and can be used interchangeably.
 interface TagPage extends CheerioAPI {
   kind: "TagPage";

--- a/src/utils/works.ts
+++ b/src/utils/works.ts
@@ -4,7 +4,7 @@ import axios from "axios";
 import { getTagUrl } from "./tags";
 
 // We create separate interfaces for each page type to make sure that the
-// corret type of page is passed to each method that extracts data.
+// correct type of page is passed to each method that extracts data.
 // Other than this, all pages are instances of CheerioAPI and can be used interchangeably.
 interface WorksPage extends CheerioAPI {
   kind: "WorksPage";


### PR DESCRIPTION
Fixed typo (corret --> correct) in `tags.ts` and `works.ts`