### PR TITLE
Update WorkSummary type

### DIFF
--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -63,7 +63,6 @@ export enum WorkWarnings {
 }
 
 export interface WorkSummary {
-  id: number;
   title: string;
   category: WorkCategory | null;
   // Date in ISO format. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
@@ -84,22 +83,20 @@ export interface WorkSummary {
     relationships: string[];
     additional: string[];
   };
-  authors: (
-    | "anonymous"
-    | "orphan_account"
+  authors:
+    | "Anonymous"
     | {
         username: string;
         // This is the name the work is published under. Might be the same as username.
         pseud: string;
-      }
-  )[];
+      }[];
   language: string;
   words: number;
   chapters: {
     published: number;
     total: number | null;
-    complete: boolean;
   };
+  complete: boolean;
   stats: {
     bookmarks: number;
     comments: number;

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -62,6 +62,11 @@ export enum WorkWarnings {
   UNDERAGE = "Underage",
 }
 
+export interface Author {
+  username: string;
+  pseud: string;
+}
+
 export interface WorkSummary {
   title: string;
   category: WorkCategory | null;
@@ -83,13 +88,7 @@ export interface WorkSummary {
     relationships: string[];
     additional: string[];
   };
-  authors:
-    | "Anonymous"
-    | {
-        username: string;
-        // This is the name the work is published under. Might be the same as username.
-        pseud: string;
-      }[];
+  authors: "Anonymous" | Author[];
   language: string;
   words: number;
   chapters: {

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -81,7 +81,6 @@ export interface WorkSummary {
   // upon access.
   adult: boolean;
   fandoms: string[];
-  warningStatus: WorkWarningStatus;
   tags: {
     warnings: WorkWarnings[];
     characters: string[];

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -68,6 +68,7 @@ export interface Author {
 }
 
 export interface WorkSummary {
+  id: number;
   title: string;
   category: WorkCategory | null;
   // Date in ISO format. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString


### PR DESCRIPTION
The changes are as follows:

- Remove the `id` property, since the method `getWorksPage` uses the id as a parameter in order to return the work summary, so that seems redundant? We discussed in the past whether we should use the URL or the workId for extracting the info, and we decided on id. [Link to that discussion](https://discord.com/channels/911351540504199168/941336771021660231/941460860126248970)

- A work with multiple authors in an anonymous collection will only display one single string value, `"Anonymous"` in the author field, so I edited the union type to reflect that. I also removed `"orphan_account"` since in practice it simply shows up as an (inaccessible) username, and pseuds are displayed like normal. For example: PseudyPseud (orphan_account), with a URL of `https://archiveofourown.org/users/orphan_account/pseuds/PseudyPseud` (which results in a 404). It seems like it's not ideal to lose the pseud info on orphaned works.

- Moved the `complete` property out of the `chapters` section, since I think having both Published and Complete there can be confusing, and complete refers to the work itself anyway.