### PR TITLE
Tweaking README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Using `setFetcher`, you can override the default `fetch` method used by the libr
 With yarn
 
 ```sh
-yarn install @fujocoded/ao3.js
+yarn add @fujocoded/ao3.js
 ```
 
 or npm


### PR DESCRIPTION
- Yarn uses `add` instead of `install` now, so I updated that.
- I just realized that one link is still wrong, so I fixed again.